### PR TITLE
Modify individual text nodes to retain links

### DIFF
--- a/addons/comments-line-break/userscript.js
+++ b/addons/comments-line-break/userscript.js
@@ -14,16 +14,20 @@
       }
 
       var content = thisNode.textContent;
-      if (i === 0) { // First text node
+      if (i === 0) {
+        // First text node
         content = content.trimStart();
       }
-      if (i === element.childNodes.length - 1) { // Last text node
+      if (i === element.childNodes.length - 1) {
+        // Last text node
         content = content.trimEnd();
       }
-      if (element.closest(".reply") && i === 2) { // "First" text node in reply (comes after parent username link)
+      if (element.closest(".reply") && i === 2) {
+        // "First" text node in reply (comes after parent username link)
         content = " " + content.trimStart();
       }
-      if (nextNode && nextNode.nodeType === document.ELEMENT_NODE && content.length) { // Text node before link
+      if (nextNode && nextNode.nodeType === document.ELEMENT_NODE && content.length) {
+        // Text node before link
         content = content.slice(0, -1);
       }
 

--- a/addons/comments-line-break/userscript.js
+++ b/addons/comments-line-break/userscript.js
@@ -7,22 +7,26 @@
 
     for (var i = 0; i < element.childNodes.length; i++) {
       var thisNode = element.childNodes[i];
-      var lastNode = element.childNodes[i - 1];
       var nextNode = element.childNodes[i + 1];
 
       if (thisNode.nodeType !== document.TEXT_NODE) {
         continue;
       }
 
-      var content = thisNode.textContent.trim();
-      if (lastNode && lastNode.nodeType === document.ELEMENT_NODE) {
-        content = " " + content;
+      var content = thisNode.textContent;
+      if (i === 0) { // First text node
+        content = content.trimStart();
       }
-      if (nextNode && nextNode.nodeType === document.ELEMENT_NODE) {
-        if (content.length > 0) {
-          content = content + " ";
-        }
+      if (i === element.childNodes.length - 1) { // Last text node
+        content = content.trimEnd();
       }
+      if (element.closest(".reply") && i === 2) { // "First" text node in reply (comes after parent username link)
+        content = " " + content.trimStart();
+      }
+      if (nextNode && nextNode.nodeType === document.ELEMENT_NODE && content.length) { // Text node before link
+        content = content.slice(0, -1);
+      }
+
       thisNode.textContent = content;
     }
 

--- a/addons/comments-line-break/userscript.js
+++ b/addons/comments-line-break/userscript.js
@@ -1,27 +1,30 @@
 ﻿export default async function ({ addon, global, console }) {
-  addon.settings.addEventListener("change", () => console.log("changed!"));
-
   while (true) {
-    await addon.tab.waitForElement(
-      ".comment-content:not(.commentsLineBreaksViewed),.comment .content:not(.commentsLineBreaksViewed)"
-    );
-    var element = document.querySelector(
+    var element = await addon.tab.waitForElement(
       ".comment-content:not(.commentsLineBreaksViewed),.comment .content:not(.commentsLineBreaksViewed)"
     );
     element.style = "white-space:break-spaces;";
 
-    if (document.querySelector(".comment .content:not(.commentsLineBreaksViewed)")) {
-      /*element.textContent = element.textContent.slice(15, element.textContent.length);
-      element.textContent = element.textContent.slice(0, element.textContent.indexOf('\n')) + 
-                            element.textContent.slice(element.textContent.indexOf('\n') + 23, element.textContent.length);*/
+    for (var i = 0; i < element.childNodes.length; i++) {
+      var thisNode = element.childNodes[i];
+      var lastNode = element.childNodes[i - 1];
+      var nextNode = element.childNodes[i + 1];
+
+      if (thisNode.nodeType !== document.TEXT_NODE) {
+        continue;
+      }
+
+      var content = thisNode.textContent.trim();
+      if (lastNode && lastNode.nodeType === document.ELEMENT_NODE) {
+        content = " " + content;
+      }
+      if (nextNode && nextNode.nodeType === document.ELEMENT_NODE) {
+        if (content.length > 0) {
+          content = content + " ";
+        }
+      }
+      thisNode.textContent = content;
     }
-
-    //var result = '\n';
-    //for(var i = 0;i < element.textContent.length;i++){
-    //  result += element.textContent[i].charCodeAt(0) + ' ';
-    //}
-
-    element.textContent += "\n\n" + element.innerHTML; //result;
 
     element.classList.add("commentsLineBreaksViewed");
   }


### PR DESCRIPTION
**Resolves**

Fixes [these issues](https://github.com/ScratchAddons/ScratchAddons/pull/209#issuecomment-691485764):

> At least not how it should. It removes a lot of stuff including links and it messes up the reply stuff.

Note this is a PR adding to the existing PR ScratchAddons/ScratchAddons#209 - it modifies the fork on @NoobTracker, which can then be merged into original master by merging said PR.

**Changes**

Modifies content by working on individual text nodes instead of the `textContent` of the comment element as a whole. There are special cases for various contexts handling each text node (see "Tests").

**Reason for changes**

Makes the addon work!

**Tests**

Tested manually with these comments [on my profile](https://scratch.mit.edu/users/_nix/#comments-92643313):

![Various comments demoing the special-cases described in the code.](https://user-images.githubusercontent.com/9948030/92996908-9011df80-f4e5-11ea-8012-5c40e3e959df.png)
